### PR TITLE
Pink (my WIP lua ink compiler) support

### DIFF
--- a/drivers/pink-runner.lua
+++ b/drivers/pink-runner.lua
@@ -1,0 +1,91 @@
+#!/bin/env lua
+
+local parser = require('pink.parser')
+local runtime = require('pink.runtime')
+
+function dump(o, indent)
+  indent = indent or 1;
+  local sp = function (ind)
+      return (" "):rep(ind*2)
+  end
+
+  if type(o) == 'table' then
+    local s = '{\n'
+    for k,v in pairs(o) do
+      if type(k) ~= 'number' then k = '"'..k..'"' end
+      s = s .. sp(indent)..'['..k..'] = ' .. dump(v, indent+1) .. ',\n'
+    end
+    return s .. sp(indent-1) .. '}'
+  elseif type(o) == 'string' then
+    return "'"..(o:gsub("\\", "\\\\"):gsub("'", "\\'")).."'"
+  else
+    return tostring(o)
+  end
+end
+
+function read(filename)
+  local f = io.open(filename, "rb")
+  if not f then error('failed to open "'..filename..'"') end
+  local content = f:read("*all")
+  f:close()
+  return content
+end
+
+function write(filename, content)
+  local f = io.open(filename, "wb")
+  if not f then error('failed to open "'..filename..'"') end
+  f:write(content)
+  f:close()
+end
+
+function exists(filename)
+  local f = io.open(filename, "r")
+  return f ~= nil and io.close(f)
+end
+
+
+local action = arg[1]
+
+if action == 'compile' then
+  local inkFile = arg[2]
+  local jsonFile = arg[3] -- needs to be created to indicate successful compilation
+  local luaFile = jsonFile:gsub('.json', '_pink.lua') -- compile result
+  write(luaFile, "return "..dump(parser(read(inkFile), inkFile)))
+  write(jsonFile, "[\"json not supported\"]")
+
+elseif action == 'run' then
+  local jsonFile = arg[2]
+  local reqLuaFile = jsonFile:gsub('.json', '_pink') -- compile result; .lua added when calling require
+
+  if not exists(reqLuaFile..".lua") then
+    io.stderr:write('only internal pink format supported\n')
+    os.exit(1)
+  end
+
+  local story = runtime(require(reqLuaFile))
+
+  while true do
+    while story.canContinue do
+      print(story.continue())
+    end
+    if #story.currentChoices == 0 then break end -- cannot continue and there are no choices
+    print()
+    for i = 1, #story.currentChoices do
+      print(i .. ": " .. story.currentChoices[i].text)
+    end
+    -- TODO tags
+    local answer = tonumber(io.read())
+    if not answer or answer > #story.currentChoices then
+      io.stderr:write('invalid answer '..tostring(answer)..'\n')
+      os.exit(1)      
+    end
+    print ('?> '..story.currentChoices[answer].choiceText)
+    story.chooseChoiceIndex(answer)
+  end
+
+
+
+
+end
+
+

--- a/drivers/pink_compiler_compiler_driver
+++ b/drivers/pink_compiler_compiler_driver
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+SRC = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pink-runner.lua')
+ROOTDIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PINKDIR = os.path.join(ROOTDIR, 'deps', 'pink')
+os.execlpe(SRC, 'pink-runner.lua', "compile", sys.argv[3], sys.argv[2], {"LUA_PATH": PINKDIR+'/?.lua'})

--- a/drivers/pink_runtime_driver
+++ b/drivers/pink_runtime_driver
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+SRC = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pink-runner.lua')
+ROOTDIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PINKDIR = os.path.join(ROOTDIR, 'deps', 'pink')
+os.execlpe(SRC, 'pink-runner.lua', "run", sys.argv[1], {"LUA_PATH": PINKDIR+'/?.lua;'+ROOTDIR+'/?.lua'})

--- a/install_deps.py
+++ b/install_deps.py
@@ -156,6 +156,12 @@ DEPS = [
      'c7818565141ec4a42bc0c6ccf415510c21729db2',
      'all'),
 
+    # Pink
+    ('deps/pink.zip',
+     'https://github.com/premek/pink/archive/8d753c3cce63f1d2d85bdb96d60f8161f63a5a69.zip',
+     '547e15b7aaa1a2a416ff9a5b6f5255a8acf61131',
+     'all'),
+
     # Tachyons
     ('deps/tachyons.min.css',
      'https://unpkg.com/tachyons@4.12.0/css/tachyons.min.css',


### PR DESCRIPTION
Closes #6 

Hi, I see you added 'initial support for incompatible versions', please let me know if I can use it (or if I should make any changes in my PR)

I didn't include the update_site.yml file changes yet (should I?) but in my fork I run it with `python3 proof.py pink_compiler pink_runtime`

Another thing I wasn't sure about was that I store my compiled "bytecode" in a new file `*_pink.lua`.
I didn't have any file format for it as it's just a lua data structure passed from the compiler to the runtime.
So I serialized it to a lua file so I can easily 'require' (include) it in the runtime script but for that it needed to be called `*.lua`

I also found it useful to be able to display it so in my fork I changed the `compileBytecodePath` link. Would it be possible to somehow add the link to the pink.lua file too? (example: https://premek.github.io/ink-proof/#!/file/pink_compiler_I002_out_pink.lua?overview=ink )

Let me know what you think

thanks