### PR TITLE
Test sequences contain each entry once per shuffle 

### DIFF
--- a/ink/I136/metadata.json
+++ b/ink/I136/metadata.json
@@ -1,0 +1,6 @@
+{
+  "oneLineDescription": "Shuffle gives all results",
+  "tags": [
+  	"sequences"
+  ]
+}

--- a/ink/I136/story.ink
+++ b/ink/I136/story.ink
@@ -1,0 +1,19 @@
+VAR loops_left = 100
+VAR ace_of_hearts = 0
+VAR ace_of_spades = 0
+-> draw_cards
+
+=== draw_cards
+{loops_left == 0: -> end}
+// every shuffle of the cards produces each card once (in a random order)
+{shuffle:
+- ~ ace_of_hearts++
+- ~ ace_of_spades++
+}
+~ loops_left--
+-> draw_cards
+
+=== end
+Hearts: {ace_of_hearts}
+Spades: {ace_of_spades}
+-> END

--- a/ink/I136/transcript.txt
+++ b/ink/I136/transcript.txt
@@ -1,0 +1,2 @@
+Hearts: 50
+Spades: 50


### PR DESCRIPTION
Adds a new test that shuffles a sequence 50 times, expecting each possible result to be pulled exactly 50 times: once per shuffle.

If this test fails, then the runtime might be drawing items *with* replacement, or might be reshuffling the sequence too often. There is an 8% chance that such a misbehaving runtime would randomly get the right result anyway, but all correct implementations will pass the test 100% of the time.